### PR TITLE
Fix shared-lock cron jitter and audit warnings

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,66 @@
+# Landing Zones App
+
+The Landing Zones app provides operator-facing commands for building, validating, and activating transfer runtimes.
+
+## Language
+
+**Landing Zone Runtime**:
+A deployed transfer environment with its own generated artifacts and operational identity.
+_Avoid_: User deployment, server deployment
+
+**Runtime ID**:
+The canonical identity of a **Landing Zone Runtime**.
+_Avoid_: System user, cron user, deploy user
+
+**Runtime-Scoped Cron Deployment**:
+A cron activation that is bounded by selected **Runtime IDs**.
+_Avoid_: User-scoped cron deployment, system-scoped cron deployment
+
+**Cron Fragment Set**:
+The Landing Zone cron files staged for one **Execution Context**.
+_Avoid_: Runtime, selected runtime
+
+**Runtime Selection**:
+The set of **Runtime IDs** chosen for cron activation.
+_Avoid_: Runtime prefix, artifact prefix, user selection
+
+**Generated Runtime Metadata**:
+The build-written list of **Runtime IDs** represented by generated runtime artifacts.
+_Avoid_: Transfer inventory, runtime scan
+
+**Unidentified Cron Fragment**:
+A staged `.cron` file that does not carry a **Runtime ID** in its filename.
+_Avoid_: Unknown runtime, invalid cron
+
+**Excluded Runtime Cron Fragment**:
+An identified runtime cron file that is staged but not selected for activation.
+_Avoid_: Deleted cron, stale cron
+
+**Execution Context**:
+The system and Unix account under which a runtime command or cron job runs.
+_Avoid_: Runtime identity, deploy boundary
+
+## Relationships
+
+- A **Landing Zone Runtime** has exactly one **Runtime ID**.
+- A **Runtime-Scoped Cron Deployment** activates cron entries for one or more selected **Runtime IDs**.
+- An **Execution Context** can host multiple **Landing Zone Runtimes**.
+- An **Execution Context** is not a sufficient deployment boundary when multiple **Runtime IDs** share it.
+- A **Cron Fragment Set** can intentionally contain cron files for multiple **Runtime IDs** on the same **Execution Context**.
+- A **Runtime Selection** defaults to the selected **Runtime ID** exactly.
+- **Generated Runtime Metadata** describes the **Runtime IDs** represented by generated runtime artifacts.
+- An **Unidentified Cron Fragment** can be preserved during activation without being treated as a **Landing Zone Runtime**.
+- An **Excluded Runtime Cron Fragment** may remain staged while being omitted from the active crontab.
+
+## Example dialogue
+
+> **Dev:** "Should cron deployment install every Landing Zone cron file for this Unix user?"
+> **Domain expert:** "No. It should deploy the selected **Runtime ID**. The Unix account is only the **Execution Context**."
+
+> **Dev:** "Can one system/account activate cron for two sequencing nodes?"
+> **Domain expert:** "Yes. The same **Execution Context** can intentionally activate a **Cron Fragment Set** containing multiple **Runtime IDs**."
+
+## Flagged ambiguities
+
+- "user" was used as both a runtime boundary and an execution account. Resolved: use **Runtime ID** for the runtime boundary and **Execution Context** for the system/account pair.
+- "prefix" was used for the selected runtime identity, but this conflicts with artifact filename prefixes. Resolved: use **Runtime Selection** and exact **Runtime ID** matching.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,46 @@ landingzones report transfers output/log/Landing_Zone_server1_prod.user1.transfe
 */15 * * * * /bin/sh output/scripts/local_copy.sh
 ```
 
+### Shared Main Transfer Locks
+
+`flock_file` is the top-level transfer lock for one generated script. Remote
+transfers run startup jitter before acquiring the main `flock_file`, then use
+non-blocking `flock -n` for the main lock. This spreads same-minute cron starts
+before the lock race, but a transfer can still skip a run if another process
+keeps the same main lock busy after the jitter. This behavior does not change
+the cron cadence in `transfers.tsv`; for example, a `*/2 * * * *` row remains a
+two-minute schedule.
+
+`landingzones build` and `landingzones validate deployment` warn with `Shared
+main transfer locks detected` when multiple transfer rows in the same runtime
+resolve to the same main `flock_file`. Treat that warning as an operator review
+item: either the shared lock is intentional serialization, or one of the rows
+should get a distinct `flock_file`.
+
+The shared main-lock warning is different from the generated
+transfer-status and notification-status locks. Files such as
+`Landing_Zone_<system>.transfers.lock` and
+`Landing_Zone_<system>.notifications.lock` protect short TSV append sections and
+are expected to be shared by all scripts for a runtime.
+
+To verify a generated script manually, hold its resolved `flock_file`, run the
+script with debug output, and check the message order:
+
+```bash
+script=/path/to/generated_transfer.sh
+lock=$(sed -n 's/^flock_file="\([^"]*\)"/\1/p' "$script" | sed "s|\$HOME|$HOME|")
+mkdir -p "$(dirname "$lock")"
+(
+  exec 200>"$lock"
+  flock -n 200
+  LZ_DEBUG_CLI=1 /bin/sh "$script"
+) 2>&1
+```
+
+For remote transfers, debug output should show `startup delay ...` before
+`using lock file ...`; if the held lock wins, the script then reports
+`lock busy, exiting`.
+
 ## Installation
 
 ```bash

--- a/docs/adr/0001-runtime-scoped-cron-activation.md
+++ b/docs/adr/0001-runtime-scoped-cron-activation.md
@@ -1,0 +1,12 @@
+# Runtime-Scoped Cron Activation
+
+Cron activation is scoped by selected runtime IDs, not by the system/user execution context, because one Unix account can intentionally stage cron fragments for multiple Landing Zone runtimes. The deployment command should present the operator with the runtime cron fragments that will be activated, unidentified `.cron` fragments that will be preserved, and identified runtime cron fragments that will be excluded before replacing the active crontab.
+
+**Consequences**
+
+- Generated runtime metadata beside the cron output is the preferred source for expected runtime IDs; generated cron filenames are a warned compatibility fallback when metadata is missing.
+- Unidentified `.cron` files are preserved by default because `crontab -` replaces the whole user crontab.
+- Cron activation scope is selected through an explicit named CLI option, with `selected` as the default and `expected` and `staged` as broader activation scopes.
+- `expected` activation prompts the operator to copy missing expected runtime cron fragments from the generated cron output into the staged cron directory before activation.
+- `expected` activation fails when an expected runtime cron fragment is missing from both the staged cron directory and the generated cron output.
+- Non-interactive cron activation fails closed unless the command includes an explicit confirmation option.

--- a/src/landingzones/check_deployment_readiness.py
+++ b/src/landingzones/check_deployment_readiness.py
@@ -103,6 +103,24 @@ def list_visible_directories(path):
     ]
 
 
+def print_shared_main_lock_warnings(transfers_df):
+    """Print shared main-lock audit warnings attached to a transfer catalog."""
+    warnings = getattr(transfers_df, 'attrs', {}).get(
+        'shared_main_lock_warnings', []
+    )
+    if not warnings:
+        return
+    print_header("Shared Main Transfer Locks")
+    print_status(
+        "Shared main transfer locks detected",
+        "WARN",
+        "Review whether shared top-level flock files are intentional serialization.",
+    )
+    for warning in warnings:
+        print("  - {0}".format(warning))
+    print()
+
+
 def endpoint_key(value):
     """Return a normalized endpoint key for comparing transfer roots."""
     remote, path = split_remote_path(value)
@@ -1573,6 +1591,8 @@ def main(argv=None):
     except Exception as e:
         print_status("Configuration file", "ERROR", "Cannot read transfers.tsv: {0}".format(e))
         return False
+
+    print_shared_main_lock_warnings(df)
     
     # Determine current system and user
     current_system = get_current_system(transfers_df=df, runtime_ids=runtime_ids)

--- a/src/landingzones/generate_cron_files.py
+++ b/src/landingzones/generate_cron_files.py
@@ -264,6 +264,10 @@ def parse_transfers_file(filename, require_runtime_files=True, runtime_ids=None,
     validate_flow_metadata(df)
     df = resolve_transfer_file_paths(df)
     df.attrs['shared_file_pair_warnings'] = audit_shared_file_pairs(df)
+    df.attrs['shared_main_lock_groups'] = audit_shared_main_locks(df)
+    df.attrs['shared_main_lock_warnings'] = format_shared_main_lock_warnings(
+        df.attrs['shared_main_lock_groups']
+    )
     
     return df
 
@@ -560,6 +564,66 @@ def audit_shared_file_pairs(df):
                 log_file,
                 flock_file,
                 ', '.join(identifiers),
+            )
+        )
+    return warnings
+
+
+def audit_shared_main_locks(df):
+    """Return structured groups for transfers sharing a main flock file."""
+    grouped = {}
+    for _, row in df.iterrows():
+        flock_file = clean_tsv_value(row.get('flock_file', ''))
+        if not flock_file:
+            continue
+        runtime_id = clean_tsv_value(
+            row.get('runtime_id', row.get('system_user', ''))
+        )
+        if not runtime_id:
+            runtime_id = legacy_runtime_id(row)
+        key = (runtime_id, flock_file)
+        grouped.setdefault(key, []).append({
+            'identifier': clean_tsv_value(row.get('identifiers', '')),
+            'frequency': clean_tsv_value(row.get('frequency', '')),
+            'log_file': clean_tsv_value(row.get('log_file', '')),
+            'system': clean_tsv_value(row.get('system', '')),
+            'user': clean_tsv_value(row.get('users', row.get('user', ''))),
+        })
+
+    shared_groups = []
+    for (runtime_id, flock_file), transfers in grouped.items():
+        if len(transfers) < 2:
+            continue
+        transfers = sorted(transfers, key=lambda item: item['identifier'])
+        shared_groups.append({
+            'runtime_id': runtime_id,
+            'flock_file': flock_file,
+            'transfers': transfers,
+        })
+    return sorted(
+        shared_groups,
+        key=lambda group: (group['runtime_id'], group['flock_file']),
+    )
+
+
+def format_shared_main_lock_warnings(shared_lock_groups):
+    """Format shared-main-lock audit groups for operator output."""
+    warnings = []
+    for group in shared_lock_groups:
+        transfers = []
+        for transfer in group['transfers']:
+            frequency = transfer.get('frequency', '') or 'default'
+            transfers.append(
+                "{0} (frequency={1})".format(
+                    transfer.get('identifier', ''),
+                    frequency,
+                )
+            )
+        warnings.append(
+            "Shared main lock: runtime_id='{0}', flock_file='{1}', transfers={2}".format(
+                group.get('runtime_id', ''),
+                group.get('flock_file', ''),
+                ', '.join(transfers),
             )
         )
     return warnings
@@ -1845,14 +1909,14 @@ on_exit() {{
 trap on_exit EXIT HUP INT TERM
 
 mkdir -p "$(dirname "$log_file")" "$(dirname "$latest_log_file")" "$(dirname "$mini_log_file")" "$(dirname "$flock_file")" "$(dirname "$common_status_log_file")" "$(dirname "$common_status_lock_file")" "$(dirname "$notification_status_log_file")" "$(dirname "$notification_status_lock_file")"
+if [ -n "$source_remote_target" ] || [ -n "$destination_remote_target" ]; then
+    random_start_delay 60
+fi
 debug "using lock file $flock_file"
 exec 9>"$flock_file"
 if ! {flock_command} -n 9; then
     debug "lock busy, exiting"
     exit 0
-fi
-if [ -n "$source_remote_target" ] || [ -n "$destination_remote_target" ]; then
-    random_start_delay 60
 fi
 {remote_destination_setup}
 
@@ -2509,6 +2573,16 @@ def main(argv=None):
             print("\n" + warning)
         print("\n" + "=" * 60)
         print("Review transfer definitions for accidental log/lock reuse.")
+        print("Continuing with generation...\n")
+
+    shared_main_lock_warnings = transfers_df.attrs.get('shared_main_lock_warnings', [])
+    if shared_main_lock_warnings:
+        print("\n\033[93m⚠ WARNING: Shared main transfer locks detected!\033[0m")
+        print("=" * 60)
+        for warning in shared_main_lock_warnings:
+            print("\n" + warning)
+        print("\n" + "=" * 60)
+        print("Review whether shared top-level flock files are intentional serialization.")
         print("Continuing with generation...\n")
     
     remove_stale_generated_scripts(

--- a/tests/test_check_deployment_readiness.py
+++ b/tests/test_check_deployment_readiness.py
@@ -227,6 +227,67 @@ class TestRuntimeIdentityDetection:
         assert result is True
         assert captured['runtime_ids'] == ['local_dev.local']
 
+    def test_validate_deployment_prints_shared_main_lock_warnings(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Deployment validation should surface shared main-lock audit warnings."""
+        src = tmp_path / "src"
+        dst = tmp_path / "dst"
+        src.mkdir()
+        dst.mkdir()
+        transfers_file = tmp_path / "transfers.tsv"
+        transfers_file.write_text("placeholder\n")
+        df = pd.DataFrame([
+            {
+                'runtime_id': 'local_dev.local',
+                'system': 'local_dev',
+                'users': 'local',
+                'source': str(src),
+                'source_port': '',
+                'destination': str(dst),
+                'destination_port': '',
+                'log_file': str(tmp_path / 'log' / 'first.log'),
+                'flock_file': str(tmp_path / 'flock' / 'shared.lock'),
+            },
+            {
+                'runtime_id': 'local_dev.local',
+                'system': 'local_dev',
+                'users': 'local',
+                'source': str(src),
+                'source_port': '',
+                'destination': str(dst),
+                'destination_port': '',
+                'log_file': str(tmp_path / 'log' / 'second.log'),
+                'flock_file': str(tmp_path / 'flock' / 'shared.lock'),
+            },
+        ])
+        df.attrs['shared_main_lock_warnings'] = [
+            "Shared main lock: runtime_id='local_dev.local', "
+            "flock_file='{0}', transfers=first (frequency=*/2 * * * *), "
+            "second (frequency=*/2 * * * *)".format(tmp_path / 'flock' / 'shared.lock')
+        ]
+
+        monkeypatch.setattr(cdr, 'check_required_tools', lambda: True)
+        monkeypatch.setattr(cdr, 'check_flock_command', lambda system: True)
+        monkeypatch.setattr(
+            cdr,
+            'load_runtime_transfers',
+            lambda transfers_file=None, runtime_ids=None: df,
+        )
+
+        config_snapshot = cdr.config.snapshot_state()
+        try:
+            cdr.config._runtime_config = {}
+            result = cdr.main(['--transfers', str(transfers_file)])
+        finally:
+            cdr.config.restore_state(config_snapshot)
+
+        captured = capsys.readouterr()
+        assert result is True
+        assert 'Shared main transfer locks detected' in captured.out
+        assert 'local_dev.local' in captured.out
+        assert 'shared.lock' in captured.out
+
 
 class TestCheckLocalDirectory:
     """Test the check_local_directory function"""

--- a/tests/test_generate_cron_files.py
+++ b/tests/test_generate_cron_files.py
@@ -489,6 +489,92 @@ second\tserver1\tuser1\t/src2/\t/dest2/\t\t\t\t/tmp/shared.log\t/tmp/shared.lock
         assert "first" in warnings[0]
         assert "second" in warnings[0]
 
+    def test_parse_records_shared_main_lock_warnings(self, tmp_path):
+        """Duplicate main locks should be reported even when logs differ."""
+        tsv_content = """identifiers\truntime_id\tsystem\tusers\tsource\tdestination\tdestination_port\trsync_options\tio_nice\tlog_file\tflock_file\tfrequency
+first\truntime_a\tserver1\tuser1\t/src1/\t/dest1/\t\t\t\t/tmp/first.log\tshared.lock\t*/2 * * * *
+second\truntime_a\tserver1\tuser1\t/src2/\t/dest2/\t\t\t\t/tmp/second.log\tshared.lock\t*/5 * * * *
+third\truntime_a\tserver1\tuser1\t/src3/\t/dest3/\t\t\t\t/tmp/third.log\tunique.lock\t*/2 * * * *
+"""
+        test_file = tmp_path / "test_transfers.tsv"
+        test_file.write_text(tsv_content)
+
+        original_runtime_config = dict(gcf.config._runtime_config)
+        gcf.config._runtime_config['rit_managed_locations'] = {
+            'server1': '/srv/rit_managed'
+        }
+        gcf.config._runtime_config['rit_managed_folder_structure'] = {
+            'flock': 'flock',
+            'log': 'log',
+        }
+        try:
+            df = gcf.parse_transfers_file(str(test_file))
+        finally:
+            gcf.config._runtime_config = original_runtime_config
+
+        warnings = df.attrs['shared_main_lock_warnings']
+        assert len(warnings) == 1
+        assert "runtime_a" in warnings[0]
+        assert "/srv/rit_managed/flock/shared.lock" in warnings[0]
+        assert "first (frequency=*/2 * * * *)" in warnings[0]
+        assert "second (frequency=*/5 * * * *)" in warnings[0]
+        assert "third" not in warnings[0]
+
+    def test_parse_shared_main_lock_audit_handles_empty_unique_and_home_paths(self, tmp_path):
+        """Only duplicate non-empty main locks in the same runtime should warn."""
+        tsv_content = """identifiers\truntime_id\tsystem\tusers\tsource\tdestination\tdestination_port\trsync_options\tio_nice\tlog_file\tflock_file\tfrequency
+home_first\truntime_a\tserver1\tuser1\t/src1/\t/dest1/\t\t\t\t/tmp/first.log\t$HOME/shared.lock\t*/2 * * * *
+home_second\truntime_a\tserver1\tuser1\t/src2/\t/dest2/\t\t\t\t/tmp/second.log\t$HOME/shared.lock\t*/2 * * * *
+other_runtime\truntime_b\tserver1\tuser1\t/src3/\t/dest3/\t\t\t\t/tmp/third.log\t$HOME/shared.lock\t*/2 * * * *
+unique\truntime_a\tserver1\tuser1\t/src4/\t/dest4/\t\t\t\t/tmp/unique.log\t/tmp/unique.lock\t*/2 * * * *
+empty\truntime_a\tserver1\tuser1\t/src5/\t/dest5/\t\t\t\t/tmp/empty.log\t\t*/2 * * * *
+"""
+        test_file = tmp_path / "test_transfers.tsv"
+        test_file.write_text(tsv_content)
+
+        df = gcf.parse_transfers_file(str(test_file))
+
+        warnings = df.attrs['shared_main_lock_warnings']
+        assert len(warnings) == 1
+        assert "runtime_a" in warnings[0]
+        assert "$HOME/shared.lock" in warnings[0]
+        assert "home_first" in warnings[0]
+        assert "home_second" in warnings[0]
+        assert "other_runtime" not in warnings[0]
+        assert "unique" not in warnings[0]
+        assert "empty" not in warnings[0]
+
+    def test_parse_shared_main_lock_audit_reports_prod_like_calc_groups(self, tmp_path):
+        """The audit should represent calc prod-style three-job shared locks."""
+        tsv_content = """identifiers\truntime_id\tsystem\tusers\tsource\tdestination\tdestination_port\trsync_options\tio_nice\tlog_file\tflock_file\tfrequency
+NS_KMA_HVH_2of3\tcalc_prod.f041664\tcalc\tf041664\t/src1/\t/dest1/\t\t\t\tNS_KMA_HVH_2of3.log\tNS_KMA_HVH.lock\t*/2 * * * *
+NS_KMA_HVH_3of3\tcalc_prod.f041664\tcalc\tf041664\t/src2/\t/dest2/\t\t\t\tNS_KMA_HVH_3of3.log\tNS_KMA_HVH.lock\t*/2 * * * *
+HVH_transition\tcalc_prod.f041664\tcalc\tf041664\t/src3/\t/dest3/\t\t\t\tHVH_transition.log\tNS_KMA_HVH.lock\t*/2 * * * *
+"""
+        test_file = tmp_path / "test_transfers.tsv"
+        test_file.write_text(tsv_content)
+
+        original_runtime_config = dict(gcf.config._runtime_config)
+        gcf.config._runtime_config['rit_managed_locations'] = {
+            'calc': '/srv/data/NGS_Kaare/rit_managed'
+        }
+        gcf.config._runtime_config['rit_managed_folder_structure'] = {
+            'flock': 'flock',
+            'log': 'log',
+        }
+        try:
+            df = gcf.parse_transfers_file(str(test_file))
+        finally:
+            gcf.config._runtime_config = original_runtime_config
+
+        warnings = df.attrs['shared_main_lock_warnings']
+        assert len(warnings) == 1
+        assert "calc_prod.f041664" in warnings[0]
+        assert "/srv/data/NGS_Kaare/rit_managed/flock/NS_KMA_HVH.lock" in warnings[0]
+        assert "HVH_transition (frequency=*/2 * * * *)" in warnings[0]
+        assert "NS_KMA_HVH_2of3 (frequency=*/2 * * * *)" in warnings[0]
+        assert "NS_KMA_HVH_3of3 (frequency=*/2 * * * *)" in warnings[0]
+
     def test_parse_reporting_mode_allows_minimal_transfer_metadata(self, tmp_path):
         """Reporting/analysis mode should not require runtime log fields."""
         tsv_content = """identifiers\tenabled\tsystem\tusers\tsource\tdestination
@@ -1057,7 +1143,7 @@ class TestGenerateRsyncCommand:
         assert 'od -An -N4 -tu4 /dev/urandom' in script
         assert 'print $1 % max' in script
         assert 'random_start_delay 60' in script
-        assert script.index('/opt/bin/flock -n 9') < script.index('random_start_delay 60')
+        assert script.index('random_start_delay 60') < script.index('/opt/bin/flock -n 9')
         assert 'log_status "$dir_name initiated"' in script
         assert 'log_status "$dir_name completed"' in script
         assert 'if ! [ -d "/source" ]; then' in script
@@ -1156,6 +1242,65 @@ class TestGenerateRsyncCommand:
         assert 'grep "^run_id" "$1" | head -n 1 | cut -f2-' in script
         assert 'cut -f2-' in script
         assert 'append_portable_event_remote "$destination_remote_target" "$destination_remote_port" "$destination_run_dir" "$event_status" "$event_message"' in script
+
+    def test_remote_transfer_delays_before_main_lock(self):
+        """Remote endpoint wrappers should jitter before trying the main lock."""
+        transfer = {
+            'identifiers': 'sample',
+            'system': 'server1',
+            'source': '/source/',
+            'source_port': '',
+            'destination': 'user@host:/dest/',
+            'destination_port': '2222',
+            'rsync_options': '',
+            'io_nice': '',
+            'log_file': '/tmp/test.log',
+            'flock_file': '/tmp/test.lock',
+            'frequency': '',
+        }
+
+        original_runtime_config = dict(gcf.config._runtime_config)
+        gcf.config._runtime_config['flock_paths'] = {'server1': '/opt/bin/flock'}
+        try:
+            script = gcf.generate_script_content(transfer)
+        finally:
+            gcf.config._runtime_config = original_runtime_config
+
+        assert 'destination_remote_target="user@host"' in script
+        remote_guard_index = script.index(
+            'if [ -n "$source_remote_target" ] || [ -n "$destination_remote_target" ]; then'
+        )
+        delay_index = script.index('random_start_delay 60')
+        open_lock_index = script.index('exec 9>"$flock_file"')
+        nonblocking_lock_index = script.index('/opt/bin/flock -n 9')
+
+        assert remote_guard_index < delay_index < open_lock_index < nonblocking_lock_index
+
+    def test_local_transfer_startup_delay_is_guarded_by_empty_remote_targets(self):
+        """Local-only wrappers should not run startup jitter at runtime."""
+        transfer = {
+            'identifiers': 'sample',
+            'system': 'server1',
+            'source': '/source/',
+            'source_port': '',
+            'destination': '/dest/',
+            'destination_port': '',
+            'rsync_options': '',
+            'io_nice': '',
+            'log_file': '/tmp/test.log',
+            'flock_file': '/tmp/test.lock',
+            'frequency': '',
+        }
+
+        script = gcf.generate_script_content(transfer)
+
+        assert 'source_remote_target=""' in script
+        assert 'destination_remote_target=""' in script
+        assert (
+            'if [ -n "$source_remote_target" ] || [ -n "$destination_remote_target" ]; then\n'
+            '    random_start_delay 60\n'
+            'fi'
+        ) in script
 
     def test_generate_script_content_includes_notification_delivery(self):
         """Generated scripts should derive notification attempts from status events."""
@@ -2023,6 +2168,43 @@ second\tlocalhost\ttestuser\t/tmp/src2/\t\t/tmp/dest2/\t\t\t\t/tmp/shared.log\t/
         assert 'first' in captured.out
         assert 'second' in captured.out
         assert (validation_scripts_dir / "lz_run_validation.sh").exists()
+
+    def test_main_prints_shared_main_lock_warning(self, tmp_path, monkeypatch, capsys):
+        """Generation should warn when different transfers share a main lock."""
+        transfers_file = tmp_path / "test_transfers.tsv"
+        output_dir = tmp_path / "crontab.d"
+        log_dir = tmp_path / "log"
+        scripts_dir = tmp_path / "scripts"
+        validation_scripts_dir = tmp_path / "validation_scripts"
+        transfers_file.write_text(
+            """identifiers\truntime_id\tsystem\tusers\tsource\tsource_port\tdestination\tdestination_port\trsync_options\tio_nice\tlog_file\tflock_file\tfrequency
+first\tlocalhost.testuser\tlocalhost\ttestuser\t/tmp/src1/\t\t/tmp/dest1/\t\t\t\t/tmp/first.log\t/tmp/shared.lock\t*/2 * * * *
+second\tlocalhost.testuser\tlocalhost\ttestuser\t/tmp/src2/\t\t/tmp/dest2/\t\t\t\t/tmp/second.log\t/tmp/shared.lock\t*/5 * * * *
+"""
+        )
+
+        monkeypatch.setattr(
+            sys,
+            'argv',
+            [
+                'generate_cron_files.py',
+                '--transfers', str(transfers_file),
+                '--output-dir', str(output_dir),
+                '--log-dir', str(log_dir),
+                '--scripts-dir', str(scripts_dir),
+                '--validation-scripts-dir', str(validation_scripts_dir),
+            ],
+        )
+
+        rc = gcf.main()
+        captured = capsys.readouterr()
+
+        assert rc == 0
+        assert 'Shared main transfer locks detected' in captured.out
+        assert 'localhost.testuser' in captured.out
+        assert '/tmp/shared.lock' in captured.out
+        assert 'first (frequency=*/2 * * * *)' in captured.out
+        assert 'second (frequency=*/5 * * * *)' in captured.out
 
 
 class TestEnvironmentVariableExpansion:

--- a/tests/test_operator_docs.py
+++ b/tests/test_operator_docs.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Tests for operator-facing documentation."""
+
+import os
+
+
+APP_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def test_readme_documents_shared_lock_startup_jitter():
+    """README should explain shared-lock jitter and operator verification."""
+    readme_path = os.path.join(APP_ROOT, "README.md")
+    readme_text = open(readme_path, "r").read()
+    normalized_readme_text = " ".join(readme_text.split())
+
+    assert "Shared Main Transfer Locks" in readme_text
+    assert "startup jitter before acquiring the main `flock_file`" in normalized_readme_text
+    assert "`flock -n`" in readme_text
+    assert "Shared main transfer locks detected" in normalized_readme_text
+    assert "transfer-status and notification-status locks" in normalized_readme_text
+    assert "LZ_DEBUG_CLI=1" in readme_text
+    assert "does not change the cron cadence" in normalized_readme_text


### PR DESCRIPTION
## Summary

- move remote-transfer startup jitter before the main non-blocking transfer lock
- add shared main-lock auditing and warnings during generation/readiness review
- document shared main-lock operator behavior and add the runtime-scoped cron glossary/ADR

## Issues

Refs ssi-dk/rit-deploy-landingzones#15.
Refs ssi-dk/rit-deploy-landingzones#17.
Refs ssi-dk/rit-deploy-landingzones#18.
Refs ssi-dk/rit-deploy-landingzones#20.
Refs ssi-dk/rit-deploy-landingzones#22.

## Tests

- `pixi run pytest` (`244 passed`)
