### PR TITLE
Implement runtime-scoped cron activation

### DIFF
--- a/src/landingzones/check_deployment_readiness.py
+++ b/src/landingzones/check_deployment_readiness.py
@@ -1110,7 +1110,12 @@ def print_runtime_filter_status(runtime_ids, runtime_filter_source):
     )
 
 
-def run_cron_deployment_prompt(runtime_ids=None, runtime_filter_source=None):
+def run_cron_deployment_prompt(
+    runtime_ids=None,
+    runtime_filter_source=None,
+    cron_scope='selected',
+    confirm_activation=False,
+):
     """Offer an interactive cron deployment for the current system/user."""
     print_runtime_filter_status(runtime_ids, runtime_filter_source)
 
@@ -1145,18 +1150,13 @@ def run_cron_deployment_prompt(runtime_ids=None, runtime_filter_source=None):
         "{0}@{1}".format(current_user, current_system),
     )
 
-    if not ask_yes_no("Do you want to deploy the cron files now?"):
-        print_status(
-            "Cron deployment",
-            "INFO",
-            "Skipped. Re-run `landingzones deploy cron` when ready.",
-        )
-        return False
-
     deploy_ok = deploy_cron_files(
         current_system,
         current_user,
         runtime_ids=runtime_ids,
+        cron_scope=cron_scope,
+        confirm_activation=confirm_activation,
+        prompt_confirmation=ask_yes_no,
     )
     if deploy_ok:
         print_status(
@@ -1535,6 +1535,17 @@ def main(argv=None):
         action='store_true',
         help='Prompt to deploy the generated cron files for the current system/user'
     )
+    parser.add_argument(
+        '--confirm-cron-activation',
+        action='store_true',
+        help='Allow non-interactive cron activation after previewing the selected scope'
+    )
+    parser.add_argument(
+        '--cron-scope',
+        choices=['selected', 'expected', 'staged'],
+        default='selected',
+        help='Cron fragment activation scope: selected, expected, or staged'
+    )
     args = parser.parse_args(argv)
     
     # Load configuration from file and/or command line arguments
@@ -1560,6 +1571,8 @@ def main(argv=None):
         return run_cron_deployment_prompt(
             runtime_ids=runtime_ids,
             runtime_filter_source=runtime_filter_source,
+            cron_scope=args.cron_scope,
+            confirm_activation=args.confirm_cron_activation,
         )
     
     print("{0}{1}".format(Colors.BOLD, Colors.BLUE))

--- a/src/landingzones/cli.py
+++ b/src/landingzones/cli.py
@@ -198,6 +198,17 @@ def build_cli_parser():
     deploy_cron_parser.add_argument('--transfers', '-t', default=None)
     deploy_cron_parser.add_argument('--validation-scripts-dir', default=None)
     deploy_cron_parser.add_argument('--runtime-id', action='append', default=None)
+    deploy_cron_parser.add_argument(
+        '--cron-scope',
+        choices=['selected', 'expected', 'staged'],
+        default=None,
+        help='Cron fragment activation scope: selected, expected, or staged',
+    )
+    deploy_cron_parser.add_argument(
+        '--confirm-cron-activation',
+        action='store_true',
+        help='Allow non-interactive cron activation after previewing the selected scope',
+    )
     deploy_cron_parser.set_defaults(handler=handle_deploy_cron)
 
     report_parser = subparsers.add_parser(
@@ -332,6 +343,9 @@ def handle_deploy_cron(args, extra_args):
     append_option(argv, '--transfers', args.transfers)
     append_option(argv, '--validation-scripts-dir', args.validation_scripts_dir)
     append_runtime_options(argv, effective_runtime_ids(args))
+    append_option(argv, '--cron-scope', args.cron_scope)
+    if args.confirm_cron_activation:
+        argv.append('--confirm-cron-activation')
     argv.append('--deploy-cron')
     return normalize_exit_code(cdr.main(argv))
 

--- a/src/landingzones/readiness_ops.py
+++ b/src/landingzones/readiness_ops.py
@@ -3,7 +3,6 @@
 """Shared readiness, preflight, and deployment helpers."""
 
 import errno
-import glob
 from io import StringIO
 import os
 import re
@@ -14,8 +13,18 @@ import subprocess
 import sys
 
 from landingzones.config import config
-from landingzones.generate_cron_files import cron_file_name, shell_path
-from landingzones.transfer_loading import load_runtime_transfers
+from landingzones.generate_cron_files import (
+    configured_artifact_prefix,
+    cron_file_name,
+    runtime_filter_metadata_path,
+    shell_path,
+)
+from landingzones.transfer_loading import (
+    discover_runtime_ids_from_crontabs,
+    load_runtime_transfers,
+    normalize_runtime_id_args,
+    read_runtime_filter_metadata,
+)
 
 
 class Colors:
@@ -505,10 +514,316 @@ def setup_crontab_directory():
         return False, "Cannot create directory {0}: {1}".format(crontab_dir, str(exc))
 
 
-def deploy_cron_files(current_system, current_user=None, runtime_ids=None):
+def staged_crontab_directory():
+    """Return the operator's staged cron fragment directory."""
+    return os.path.expandvars(os.path.expanduser("~/crontab.d"))
+
+
+def cron_runtime_id_from_filename(filename):
+    """Return a runtime_id for generated Landing Zone cron filenames."""
+    suffix = '.Landing_Zone.cron'
+    if not filename.endswith(suffix):
+        return None
+    stem = filename[:-len(suffix)]
+    prefix = configured_artifact_prefix()
+    if prefix:
+        prefix_text = "{0}.".format(prefix)
+        if not stem.startswith(prefix_text):
+            return None
+        stem = stem[len(prefix_text):]
+    return stem or None
+
+
+def staged_cron_fragments(crontab_dir):
+    """Return sorted staged .cron fragment paths."""
+    if not os.path.isdir(crontab_dir):
+        return []
+    return [
+        os.path.join(crontab_dir, entry)
+        for entry in sorted(os.listdir(crontab_dir))
+        if entry.endswith('.cron') and os.path.isfile(os.path.join(crontab_dir, entry))
+    ]
+
+
+def classify_cron_fragments(cron_files):
+    """Classify staged cron fragments as generated runtime or unidentified."""
+    identified = []
+    unidentified = []
+    for path in cron_files:
+        filename = os.path.basename(path)
+        runtime_id = cron_runtime_id_from_filename(filename)
+        if runtime_id:
+            identified.append({
+                'filename': filename,
+                'path': path,
+                'runtime_id': runtime_id,
+            })
+        else:
+            unidentified.append({
+                'filename': filename,
+                'path': path,
+            })
+    return identified, unidentified
+
+
+def print_cron_fragment_list(title, fragments, status="INFO"):
+    """Print a deterministic cron fragment preview line."""
+    filenames = [fragment['filename'] for fragment in fragments]
+    details = ', '.join(filenames) if filenames else '(none)'
+    print_status(title, status, details)
+
+
+def print_cron_activation_preview(
+    cron_scope,
+    activated_runtime_fragments,
+    preserved_unidentified_fragments,
+    excluded_runtime_fragments,
+):
+    """Show the operator exactly which staged cron fragments will be activated."""
+    print_header("Cron Activation Preview")
+    print_status("Cron activation scope", "INFO", cron_scope)
+    if cron_scope == 'staged':
+        print_status(
+            "Staged cron activation",
+            "WARN",
+            "Every staged .cron file will be activated.",
+        )
+    print_cron_fragment_list(
+        "Activated runtime fragments",
+        activated_runtime_fragments,
+        "OK" if activated_runtime_fragments else "WARN",
+    )
+    print_cron_fragment_list(
+        "Preserved Unidentified Cron Fragments",
+        preserved_unidentified_fragments,
+    )
+    print_cron_fragment_list(
+        "Excluded runtime cron fragments",
+        excluded_runtime_fragments,
+    )
+
+
+def is_interactive_terminal():
+    """Return whether stdin can receive an operator confirmation prompt."""
+    return sys.stdin.isatty()
+
+
+def cron_activation_confirmed(
+    cron_scope,
+    confirm_activation=False,
+    prompt_confirmation=None,
+):
+    """Require explicit approval before replacing the active crontab."""
+    if confirm_activation:
+        return True
+    if not is_interactive_terminal():
+        print_status(
+            "Crontab activation",
+            "ERROR",
+            (
+                "Non-interactive cron activation for scope '{0}' requires "
+                "--confirm-cron-activation."
+            ).format(cron_scope),
+        )
+        return False
+    if prompt_confirmation is None:
+        response = input(
+            "Replace active crontab using cron scope '{0}'? (y/N): ".format(
+                cron_scope
+            )
+        ).strip().lower()
+        return response in ('y', 'yes')
+    return prompt_confirmation(
+        "Replace active crontab using cron scope '{0}'?".format(cron_scope)
+    )
+
+
+def activate_cron_fragments(cron_files):
+    """Replace the active crontab with the provided cron fragment contents."""
+    content_parts = []
+    for cron_file in cron_files:
+        with open(cron_file, 'r') as handle:
+            content = handle.read()
+        content_parts.append(content)
+        if content and not content.endswith('\n'):
+            content_parts.append('\n')
+    active_content = ''.join(content_parts).encode('utf-8')
+
+    proc = subprocess.Popen(
+        ['crontab', '-'],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    _, stderr = proc.communicate(input=active_content)
+    result_stderr = stderr.decode('utf-8')
+
+    if proc.returncode != 0:
+        print_status(
+            "Crontab activation",
+            "ERROR",
+            "Failed: {0}".format(result_stderr.strip()),
+        )
+        return False
+
+    print_status(
+        "Crontab activation",
+        "OK",
+        "Activated {0} cron files".format(len(cron_files)),
+    )
+    verify_proc = subprocess.Popen(
+        ['crontab', '-l'],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    verify_stdout, _ = verify_proc.communicate()
+    if verify_proc.returncode == 0:
+        lines = verify_stdout.decode('utf-8').split('\n')
+        active_jobs = len([
+            line for line in lines
+            if line.strip() and not line.startswith('#')
+        ])
+        print_status(
+            "Crontab verification",
+            "OK",
+            "Total active cron jobs: {0}".format(active_jobs),
+        )
+    return True
+
+
+def copy_generated_runtime_crons(
+    runtime_ids,
+    crontab_dir,
+    repair_missing=False,
+    confirm_activation=False,
+    prompt_confirmation=None,
+):
+    """Copy generated selected runtime cron fragments into the staged directory."""
+    copied_files = []
+    missing_runtime_ids = []
+    for runtime_id in runtime_ids:
+        filename = cron_file_name(runtime_id)
+        generated_path = os.path.join(config.crontab_dir, filename)
+        staged_path = os.path.join(crontab_dir, filename)
+        if os.path.exists(generated_path):
+            if repair_missing and os.path.exists(staged_path):
+                continue
+            if repair_missing and not confirm_activation:
+                if not is_interactive_terminal():
+                    print_status(
+                        "Cron staged-file repair",
+                        "ERROR",
+                        (
+                            "Missing expected runtime cron fragment {0} cannot "
+                            "be repaired non-interactively without "
+                            "--confirm-cron-activation."
+                        ).format(filename),
+                    )
+                    return None, None
+                if prompt_confirmation is None:
+                    response = input(
+                        "Copy missing expected runtime cron fragment {0} "
+                        "into ~/crontab.d before activation? (y/N): ".format(
+                            filename
+                        )
+                    ).strip().lower()
+                    should_copy = response in ('y', 'yes')
+                else:
+                    should_copy = prompt_confirmation(
+                        (
+                            "Copy missing expected runtime cron fragment {0} "
+                            "into ~/crontab.d before activation?"
+                        ).format(filename)
+                    )
+                if not should_copy:
+                    print_status(
+                        "Cron staged-file repair",
+                        "ERROR",
+                        "Missing expected runtime cron fragment was not copied: {0}".format(
+                            filename
+                        ),
+                    )
+                    return None, None
+            try:
+                shutil.copy2(generated_path, staged_path)
+                copied_files.append(filename)
+                print_status(
+                    "Copy {0}".format(filename),
+                    "OK",
+                    "Copied to {0}".format(staged_path),
+                )
+            except Exception as exc:
+                print_status(
+                    "Copy {0}".format(generated_path),
+                    "ERROR",
+                    "Failed: {0}".format(str(exc)),
+                )
+                return None, None
+        elif not os.path.exists(staged_path):
+            missing_runtime_ids.append(runtime_id)
+    return copied_files, missing_runtime_ids
+
+
+def resolve_expected_runtime_ids():
+    """Resolve runtime IDs represented by the latest generated cron output."""
+    metadata_path = runtime_filter_metadata_path(config.crontab_dir)
+    if os.path.exists(metadata_path):
+        runtime_ids = read_runtime_filter_metadata(config.crontab_dir)
+        if runtime_ids:
+            print_status(
+                "Expected runtime metadata",
+                "OK",
+                "Using {0}".format(metadata_path),
+            )
+        return runtime_ids
+
+    runtime_ids = discover_runtime_ids_from_crontabs(config.crontab_dir)
+    if runtime_ids:
+        print_status(
+            "Expected runtime metadata",
+            "WARN",
+            (
+                "Missing {0}; discovered expected runtime IDs from generated "
+                "cron filenames."
+            ).format(metadata_path),
+        )
+    return runtime_ids
+
+
+def select_cron_fragments_for_activation(cron_scope, runtime_ids, crontab_dir):
+    """Select staged cron fragments according to the requested activation scope."""
+    cron_files = staged_cron_fragments(crontab_dir)
+    identified, unidentified = classify_cron_fragments(cron_files)
+    runtime_id_set = set(runtime_ids or [])
+    if cron_scope in ('selected', 'expected'):
+        activated_runtime = [
+            fragment for fragment in identified
+            if fragment['runtime_id'] in runtime_id_set
+        ]
+        excluded_runtime = [
+            fragment for fragment in identified
+            if fragment['runtime_id'] not in runtime_id_set
+        ]
+        active_files = [
+            fragment['path']
+            for fragment in activated_runtime + unidentified
+        ]
+        return active_files, activated_runtime, unidentified, excluded_runtime
+    return cron_files, identified, unidentified, []
+
+
+def deploy_cron_files(
+    current_system,
+    current_user=None,
+    runtime_ids=None,
+    cron_scope='selected',
+    confirm_activation=False,
+    prompt_confirmation=None,
+):
     """Deploy cron files for the current system and user."""
     if runtime_ids is None:
         runtime_ids = config.runtime_ids
+    runtime_ids = normalize_runtime_id_args(runtime_ids)
     if current_user is None:
         current_user = os.environ.get('USER', os.environ.get('USERNAME', ''))
 
@@ -520,6 +835,9 @@ def deploy_cron_files(current_system, current_user=None, runtime_ids=None):
     if not dir_ok:
         return False
 
+    if cron_scope == 'expected':
+        runtime_ids = resolve_expected_runtime_ids()
+
     print_status("Generating cron files", "INFO", "Using landingzones.generate_cron_files")
     gen_ok, gen_msg = generate_cron_files(runtime_ids=runtime_ids)
     if not gen_ok:
@@ -528,64 +846,67 @@ def deploy_cron_files(current_system, current_user=None, runtime_ids=None):
     else:
         print_status("Cron file generation", "OK", gen_msg)
 
-    try:
-        if runtime_ids:
-            cron_files = [
-                os.path.join(config.crontab_dir, cron_file_name(runtime_id))
-                for runtime_id in runtime_ids
-            ]
-            cron_files = [path for path in cron_files if os.path.exists(path)]
-            expected = ', '.join(runtime_ids)
-        else:
-            pattern = os.path.join(
-                config.crontab_dir,
-                "{0}.{1}.Landing_Zone.cron".format(current_system, current_user),
-            )
-            cron_files = glob.glob(pattern)
-            expected = "{0}@{1}".format(current_user, current_system)
-        if not cron_files:
-            msg = "No new cron files for '{0}'. Using existing crontab.d/".format(expected)
-            print_status("Cron file discovery", "WARN", msg)
-            return True
-        print_status("Cron file discovery", "OK", "Found {0} files".format(len(cron_files)))
-    except Exception as exc:
-        print_status("Cron file discovery", "ERROR", "Search failed: {0}".format(str(exc)))
+    crontab_dir = staged_crontab_directory()
+    if cron_scope in ('selected', 'expected') and not runtime_ids:
+        scope_label = "selected" if cron_scope == 'selected' else "expected"
+        print_status(
+            "Cron file discovery",
+            "ERROR",
+            "No {0} runtime IDs available for cron activation.".format(
+                scope_label
+            ),
+        )
         return False
 
-    crontab_dir = os.path.expandvars(os.path.expanduser("~/crontab.d"))
-    copied_files = []
-    for cron_file in cron_files:
-        try:
-            filename = os.path.basename(cron_file)
-            dest_path = os.path.join(crontab_dir, filename)
-            shutil.copy2(cron_file, dest_path)
-            copied_files.append(filename)
-            print_status("Copy {0}".format(filename), "OK", "Copied to {0}".format(dest_path))
-        except Exception as exc:
-            print_status("Copy {0}".format(cron_file), "ERROR", "Failed: {0}".format(str(exc)))
-            return False
+    copied_files, missing_runtime_ids = copy_generated_runtime_crons(
+        runtime_ids,
+        crontab_dir,
+        repair_missing=cron_scope == 'expected',
+        confirm_activation=confirm_activation,
+        prompt_confirmation=prompt_confirmation,
+    )
+    if copied_files is None:
+        return False
+    if missing_runtime_ids:
+        print_status(
+            "Cron file discovery",
+            "ERROR",
+            "Missing generated or staged cron fragments for runtime_id: {0}. Rebuild generated cron output before retrying.".format(
+                ', '.join(missing_runtime_ids)
+            ),
+        )
+        return False
 
-    if not copied_files:
-        return True
+    active_files, activated_runtime, unidentified, excluded_runtime = (
+        select_cron_fragments_for_activation(cron_scope, runtime_ids, crontab_dir)
+    )
+    if not active_files:
+        print_status(
+            "Cron file discovery",
+            "ERROR",
+            "No staged cron fragments selected for activation.",
+        )
+        return False
+    print_cron_activation_preview(
+        cron_scope,
+        activated_runtime,
+        unidentified,
+        excluded_runtime,
+    )
+    if not cron_activation_confirmed(
+        cron_scope,
+        confirm_activation=confirm_activation,
+        prompt_confirmation=prompt_confirmation,
+    ):
+        print_status(
+            "Crontab activation",
+            "INFO",
+            "Skipped activation for cron scope '{0}'.".format(cron_scope),
+        )
+        return False
 
     try:
-        cmd = "cat {0} | crontab -".format(os.path.join(crontab_dir, "*.cron"))
-        proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        _, stderr = proc.communicate()
-        result_stderr = stderr.decode('utf-8')
-
-        if proc.returncode != 0:
-            print_status("Crontab activation", "ERROR", "Failed: {0}".format(result_stderr.strip()))
-            return False
-
-        print_status("Crontab activation", "OK", "Activated {0} cron files".format(len(copied_files)))
-        verify_proc = subprocess.Popen(['crontab', '-l'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        verify_stdout, _ = verify_proc.communicate()
-        if verify_proc.returncode == 0:
-            lines = verify_stdout.decode('utf-8').split('\n')
-            active_jobs = len([line for line in lines if line.strip() and not line.startswith('#')])
-            print_status("Crontab verification", "OK", "Total active cron jobs: {0}".format(active_jobs))
-        return True
+        return activate_cron_fragments(active_files)
     except Exception as exc:
         print_status("Crontab activation", "ERROR", "Error: {0}".format(str(exc)))
         return False

--- a/tests/test_check_deployment_readiness.py
+++ b/tests/test_check_deployment_readiness.py
@@ -107,6 +107,613 @@ class TestCronDeploymentPrompt:
 
         assert result is True
 
+    def test_deploy_cron_defaults_to_selected_runtime_scope(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Default cron activation should activate selected runtimes and preserve unidentified crons."""
+        home_dir = tmp_path / "home"
+        staged_dir = home_dir / "crontab.d"
+        generated_dir = tmp_path / "output" / "crontab.d"
+        staged_dir.mkdir(parents=True)
+        generated_dir.mkdir(parents=True)
+
+        selected_name = "local_dev.local.Landing_Zone.cron"
+        excluded_name = "other.local.Landing_Zone.cron"
+        unidentified_name = "manual-maintenance.cron"
+        (generated_dir / selected_name).write_text("* * * * * selected-runtime\n")
+        (staged_dir / excluded_name).write_text("* * * * * excluded-runtime\n")
+        (staged_dir / unidentified_name).write_text("* * * * * manual-maintenance\n")
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("crontab_dir: {0}\n".format(generated_dir))
+
+        activated = {}
+
+        class DummyProcess:
+            def __init__(
+                self,
+                args,
+                stdout=None,
+                stderr=None,
+                stdin=None,
+                shell=False,
+            ):
+                self.args = args
+                self.returncode = 0
+                self.shell = shell
+
+            def communicate(self, input=None):
+                if self.args == ['crontab', '-']:
+                    activated['content'] = input.decode('utf-8')
+                    return b'', b''
+                if self.args == ['crontab', '-l']:
+                    return activated.get('content', '').encode('utf-8'), b''
+                return b'', b''
+
+        snapshot = cdr.config.snapshot_state()
+        responses = iter(['y'])
+        monkeypatch.setenv('HOME', str(home_dir))
+        monkeypatch.setattr(ro, 'generate_cron_files', lambda runtime_ids=None: (True, "generated"))
+        monkeypatch.setattr(ro.subprocess, 'Popen', DummyProcess)
+        monkeypatch.setattr(ro, 'is_interactive_terminal', lambda: True, raising=False)
+        monkeypatch.setattr(
+            cdr,
+            'load_runtime_transfers',
+            lambda transfers_file=None, runtime_ids=None: pd.DataFrame([
+                {
+                    'runtime_id': 'local_dev.local',
+                    'system': 'local_dev',
+                    'users': 'local',
+                }
+            ]),
+        )
+        monkeypatch.setattr(
+            cdr,
+            'get_current_system',
+            lambda transfers_df=None, runtime_ids=None: 'local_dev',
+        )
+        monkeypatch.setattr(
+            cdr,
+            'get_current_user',
+            lambda transfers_df=None, runtime_ids=None: 'local',
+        )
+        monkeypatch.setattr('builtins.input', lambda: next(responses))
+
+        try:
+            result = cdr.main([
+                '--config', str(config_file),
+                '--runtime-id', 'local_dev.local',
+                '--deploy-cron',
+            ])
+        finally:
+            cdr.config.restore_state(snapshot)
+
+        captured = capsys.readouterr()
+
+        assert result is True
+        assert "selected-runtime" in activated['content']
+        assert "manual-maintenance" in activated['content']
+        assert "excluded-runtime" not in activated['content']
+        assert excluded_name in captured.out
+        assert "Excluded runtime cron fragments" in captured.out
+
+    def test_deploy_cron_confirm_option_allows_noninteractive_activation(
+        self, tmp_path, monkeypatch
+    ):
+        """An explicit confirmation option should allow non-interactive cron activation."""
+        home_dir = tmp_path / "home"
+        staged_dir = home_dir / "crontab.d"
+        generated_dir = tmp_path / "output" / "crontab.d"
+        staged_dir.mkdir(parents=True)
+        generated_dir.mkdir(parents=True)
+
+        selected_name = "local_dev.local.Landing_Zone.cron"
+        (generated_dir / selected_name).write_text("* * * * * selected-runtime\n")
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("crontab_dir: {0}\n".format(generated_dir))
+        activated = {}
+
+        class DummyProcess:
+            def __init__(self, args, stdout=None, stderr=None, stdin=None):
+                self.args = args
+                self.returncode = 0
+
+            def communicate(self, input=None):
+                if self.args == ['crontab', '-']:
+                    activated['content'] = input.decode('utf-8')
+                    return b'', b''
+                if self.args == ['crontab', '-l']:
+                    return activated.get('content', '').encode('utf-8'), b''
+                return b'', b''
+
+        snapshot = cdr.config.snapshot_state()
+        monkeypatch.setenv('HOME', str(home_dir))
+        monkeypatch.setattr(ro, 'generate_cron_files', lambda runtime_ids=None: (True, "generated"))
+        monkeypatch.setattr(ro.subprocess, 'Popen', DummyProcess)
+        monkeypatch.setattr(ro, 'is_interactive_terminal', lambda: False, raising=False)
+        monkeypatch.setattr(
+            cdr,
+            'load_runtime_transfers',
+            lambda transfers_file=None, runtime_ids=None: pd.DataFrame([
+                {
+                    'runtime_id': 'local_dev.local',
+                    'system': 'local_dev',
+                    'users': 'local',
+                }
+            ]),
+        )
+        monkeypatch.setattr(
+            cdr,
+            'get_current_system',
+            lambda transfers_df=None, runtime_ids=None: 'local_dev',
+        )
+        monkeypatch.setattr(
+            cdr,
+            'get_current_user',
+            lambda transfers_df=None, runtime_ids=None: 'local',
+        )
+        monkeypatch.setattr(
+            'builtins.input',
+            lambda: pytest.fail('non-interactive confirmation should not prompt'),
+        )
+
+        try:
+            result = cdr.main([
+                '--config', str(config_file),
+                '--runtime-id', 'local_dev.local',
+                '--deploy-cron',
+                '--confirm-cron-activation',
+            ])
+        finally:
+            cdr.config.restore_state(snapshot)
+
+        assert result is True
+        assert "selected-runtime" in activated['content']
+
+    def test_deploy_cron_expected_scope_uses_generated_runtime_metadata(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Expected scope should activate runtime IDs recorded by the generated metadata."""
+        home_dir = tmp_path / "home"
+        staged_dir = home_dir / "crontab.d"
+        output_dir = tmp_path / "output"
+        generated_dir = output_dir / "crontab.d"
+        staged_dir.mkdir(parents=True)
+        generated_dir.mkdir(parents=True)
+
+        first_name = "local_dev.local.Landing_Zone.cron"
+        second_name = "server2.runner.Landing_Zone.cron"
+        excluded_name = "other.local.Landing_Zone.cron"
+        manual_name = "manual-maintenance.cron"
+        (output_dir / "runtime_ids.txt").write_text(
+            "local_dev.local\nserver2.runner\n"
+        )
+        (generated_dir / first_name).write_text("* * * * * first-expected\n")
+        (generated_dir / second_name).write_text("* * * * * second-expected\n")
+        (staged_dir / excluded_name).write_text("* * * * * excluded-runtime\n")
+        (staged_dir / manual_name).write_text("* * * * * manual-maintenance\n")
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("crontab_dir: {0}\n".format(generated_dir))
+        activated = {}
+
+        class DummyProcess:
+            def __init__(self, args, stdout=None, stderr=None, stdin=None):
+                self.args = args
+                self.returncode = 0
+
+            def communicate(self, input=None):
+                if self.args == ['crontab', '-']:
+                    activated['content'] = input.decode('utf-8')
+                    return b'', b''
+                if self.args == ['crontab', '-l']:
+                    return activated.get('content', '').encode('utf-8'), b''
+                return b'', b''
+
+        snapshot = cdr.config.snapshot_state()
+        monkeypatch.setenv('HOME', str(home_dir))
+        monkeypatch.setattr(ro, 'generate_cron_files', lambda runtime_ids=None: (True, "generated"))
+        monkeypatch.setattr(ro.subprocess, 'Popen', DummyProcess)
+        monkeypatch.setattr(ro, 'is_interactive_terminal', lambda: False, raising=False)
+        monkeypatch.setattr(
+            cdr,
+            'load_runtime_transfers',
+            lambda transfers_file=None, runtime_ids=None: pd.DataFrame([
+                {
+                    'runtime_id': runtime_id,
+                    'system': runtime_id.split('.', 1)[0],
+                    'users': 'runner',
+                }
+                for runtime_id in runtime_ids
+            ]),
+        )
+        monkeypatch.setattr(
+            cdr,
+            'get_current_system',
+            lambda transfers_df=None, runtime_ids=None: 'local_dev',
+        )
+        monkeypatch.setattr(
+            cdr,
+            'get_current_user',
+            lambda transfers_df=None, runtime_ids=None: 'local',
+        )
+
+        try:
+            result = cdr.main([
+                '--config', str(config_file),
+                '--deploy-cron',
+                '--cron-scope', 'expected',
+                '--confirm-cron-activation',
+            ])
+        finally:
+            cdr.config.restore_state(snapshot)
+
+        captured = capsys.readouterr()
+
+        assert result is True
+        assert "first-expected" in activated['content']
+        assert "second-expected" in activated['content']
+        assert "manual-maintenance" in activated['content']
+        assert "excluded-runtime" not in activated['content']
+        assert "Cron activation scope" in captured.out
+        assert "expected" in captured.out
+        assert excluded_name in captured.out
+
+    def test_deploy_cron_expected_scope_prompts_to_repair_missing_staged_cron(
+        self, tmp_path, monkeypatch
+    ):
+        """Expected scope should prompt before copying missing staged runtime crons."""
+        home_dir = tmp_path / "home"
+        staged_dir = home_dir / "crontab.d"
+        output_dir = tmp_path / "output"
+        generated_dir = output_dir / "crontab.d"
+        staged_dir.mkdir(parents=True)
+        generated_dir.mkdir(parents=True)
+
+        staged_name = "local_dev.local.Landing_Zone.cron"
+        missing_staged_name = "server2.runner.Landing_Zone.cron"
+        (output_dir / "runtime_ids.txt").write_text(
+            "local_dev.local\nserver2.runner\n"
+        )
+        (staged_dir / staged_name).write_text("* * * * * already-staged\n")
+        (generated_dir / missing_staged_name).write_text("* * * * * repaired-runtime\n")
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("crontab_dir: {0}\n".format(generated_dir))
+        activated = {}
+        prompts = []
+
+        class DummyProcess:
+            def __init__(self, args, stdout=None, stderr=None, stdin=None):
+                self.args = args
+                self.returncode = 0
+
+            def communicate(self, input=None):
+                if self.args == ['crontab', '-']:
+                    activated['content'] = input.decode('utf-8')
+                    return b'', b''
+                if self.args == ['crontab', '-l']:
+                    return activated.get('content', '').encode('utf-8'), b''
+                return b'', b''
+
+        def confirm(prompt_text):
+            prompts.append(prompt_text)
+            return True
+
+        snapshot = cdr.config.snapshot_state()
+        monkeypatch.setenv('HOME', str(home_dir))
+        monkeypatch.setattr(ro, 'generate_cron_files', lambda runtime_ids=None: (True, "generated"))
+        monkeypatch.setattr(ro.subprocess, 'Popen', DummyProcess)
+        monkeypatch.setattr(ro, 'is_interactive_terminal', lambda: True, raising=False)
+        monkeypatch.setattr(cdr, 'ask_yes_no', confirm)
+        monkeypatch.setattr(
+            cdr,
+            'load_runtime_transfers',
+            lambda transfers_file=None, runtime_ids=None: pd.DataFrame([
+                {
+                    'runtime_id': runtime_id,
+                    'system': runtime_id.split('.', 1)[0],
+                    'users': 'runner',
+                }
+                for runtime_id in runtime_ids
+            ]),
+        )
+        monkeypatch.setattr(
+            cdr,
+            'get_current_system',
+            lambda transfers_df=None, runtime_ids=None: 'local_dev',
+        )
+        monkeypatch.setattr(
+            cdr,
+            'get_current_user',
+            lambda transfers_df=None, runtime_ids=None: 'local',
+        )
+
+        try:
+            result = cdr.main([
+                '--config', str(config_file),
+                '--deploy-cron',
+                '--cron-scope', 'expected',
+            ])
+        finally:
+            cdr.config.restore_state(snapshot)
+
+        assert result is True
+        assert any("Copy missing expected runtime cron fragment" in prompt for prompt in prompts)
+        assert (staged_dir / missing_staged_name).exists()
+        assert "already-staged" in activated['content']
+        assert "repaired-runtime" in activated['content']
+
+    def test_deploy_cron_expected_scope_falls_back_to_generated_filenames(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Expected scope should warn and infer runtime IDs from generated cron names."""
+        home_dir = tmp_path / "home"
+        output_dir = tmp_path / "output"
+        generated_dir = output_dir / "crontab.d"
+        generated_dir.mkdir(parents=True)
+
+        (generated_dir / "local_dev.local.Landing_Zone.cron").write_text(
+            "* * * * * first-expected\n"
+        )
+        (generated_dir / "server2.runner.Landing_Zone.cron").write_text(
+            "* * * * * second-expected\n"
+        )
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("crontab_dir: {0}\n".format(generated_dir))
+        activated = {}
+
+        class DummyProcess:
+            def __init__(self, args, stdout=None, stderr=None, stdin=None):
+                self.args = args
+                self.returncode = 0
+
+            def communicate(self, input=None):
+                if self.args == ['crontab', '-']:
+                    activated['content'] = input.decode('utf-8')
+                    return b'', b''
+                if self.args == ['crontab', '-l']:
+                    return activated.get('content', '').encode('utf-8'), b''
+                return b'', b''
+
+        snapshot = cdr.config.snapshot_state()
+        monkeypatch.setenv('HOME', str(home_dir))
+        monkeypatch.setattr(ro, 'generate_cron_files', lambda runtime_ids=None: (True, "generated"))
+        monkeypatch.setattr(ro.subprocess, 'Popen', DummyProcess)
+        monkeypatch.setattr(ro, 'is_interactive_terminal', lambda: False, raising=False)
+        monkeypatch.setattr(
+            cdr,
+            'get_current_system',
+            lambda transfers_df=None, runtime_ids=None: 'local_dev',
+        )
+        monkeypatch.setattr(
+            cdr,
+            'get_current_user',
+            lambda transfers_df=None, runtime_ids=None: 'local',
+        )
+
+        try:
+            result = cdr.main([
+                '--config', str(config_file),
+                '--deploy-cron',
+                '--cron-scope', 'expected',
+                '--confirm-cron-activation',
+            ])
+        finally:
+            cdr.config.restore_state(snapshot)
+
+        captured = capsys.readouterr()
+
+        assert result is True
+        assert "first-expected" in activated['content']
+        assert "second-expected" in activated['content']
+        assert "WARNING" in captured.out
+        assert "generated cron filenames" in captured.out
+
+    def test_deploy_cron_expected_scope_fails_when_expected_cron_is_unrecoverable(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Expected scope should fail when a metadata runtime has no staged or generated cron."""
+        home_dir = tmp_path / "home"
+        staged_dir = home_dir / "crontab.d"
+        output_dir = tmp_path / "output"
+        generated_dir = output_dir / "crontab.d"
+        staged_dir.mkdir(parents=True)
+        generated_dir.mkdir(parents=True)
+
+        (output_dir / "runtime_ids.txt").write_text("missing.runtime\n")
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("crontab_dir: {0}\n".format(generated_dir))
+        activated = {}
+
+        class DummyProcess:
+            def __init__(self, args, stdout=None, stderr=None, stdin=None):
+                self.args = args
+                self.returncode = 0
+
+            def communicate(self, input=None):
+                if self.args == ['crontab', '-']:
+                    activated['content'] = input.decode('utf-8')
+                return b'', b''
+
+        snapshot = cdr.config.snapshot_state()
+        monkeypatch.setenv('HOME', str(home_dir))
+        monkeypatch.setattr(ro, 'generate_cron_files', lambda runtime_ids=None: (True, "generated"))
+        monkeypatch.setattr(ro.subprocess, 'Popen', DummyProcess)
+        monkeypatch.setattr(ro, 'is_interactive_terminal', lambda: False, raising=False)
+        monkeypatch.setattr(
+            cdr,
+            'load_runtime_transfers',
+            lambda transfers_file=None, runtime_ids=None: pd.DataFrame([
+                {
+                    'runtime_id': 'missing.runtime',
+                    'system': 'missing',
+                    'users': 'runner',
+                }
+            ]),
+        )
+        monkeypatch.setattr(
+            cdr,
+            'get_current_system',
+            lambda transfers_df=None, runtime_ids=None: 'missing',
+        )
+        monkeypatch.setattr(
+            cdr,
+            'get_current_user',
+            lambda transfers_df=None, runtime_ids=None: 'runner',
+        )
+
+        try:
+            result = cdr.main([
+                '--config', str(config_file),
+                '--deploy-cron',
+                '--cron-scope', 'expected',
+                '--confirm-cron-activation',
+            ])
+        finally:
+            cdr.config.restore_state(snapshot)
+
+        captured = capsys.readouterr()
+
+        assert result is False
+        assert 'content' not in activated
+        assert "missing.runtime" in captured.out
+        assert "rebuild" in captured.out.lower()
+
+    def test_deploy_cron_staged_scope_activates_every_staged_cron(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Staged scope should activate every .cron file in ~/crontab.d."""
+        home_dir = tmp_path / "home"
+        staged_dir = home_dir / "crontab.d"
+        generated_dir = tmp_path / "output" / "crontab.d"
+        staged_dir.mkdir(parents=True)
+        generated_dir.mkdir(parents=True)
+
+        (staged_dir / "local_dev.local.Landing_Zone.cron").write_text(
+            "* * * * * first-staged\n"
+        )
+        (staged_dir / "server2.runner.Landing_Zone.cron").write_text(
+            "* * * * * second-staged\n"
+        )
+        (staged_dir / "manual-maintenance.cron").write_text(
+            "* * * * * manual-maintenance\n"
+        )
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("crontab_dir: {0}\n".format(generated_dir))
+        activated = {}
+
+        class DummyProcess:
+            def __init__(self, args, stdout=None, stderr=None, stdin=None):
+                self.args = args
+                self.returncode = 0
+
+            def communicate(self, input=None):
+                if self.args == ['crontab', '-']:
+                    activated['content'] = input.decode('utf-8')
+                    return b'', b''
+                if self.args == ['crontab', '-l']:
+                    return activated.get('content', '').encode('utf-8'), b''
+                return b'', b''
+
+        snapshot = cdr.config.snapshot_state()
+        monkeypatch.setenv('HOME', str(home_dir))
+        monkeypatch.setattr(ro, 'generate_cron_files', lambda runtime_ids=None: (True, "generated"))
+        monkeypatch.setattr(ro.subprocess, 'Popen', DummyProcess)
+        monkeypatch.setattr(ro, 'is_interactive_terminal', lambda: False, raising=False)
+        monkeypatch.setattr(
+            cdr,
+            'get_current_system',
+            lambda transfers_df=None, runtime_ids=None: 'local_dev',
+        )
+        monkeypatch.setattr(
+            cdr,
+            'get_current_user',
+            lambda transfers_df=None, runtime_ids=None: 'local',
+        )
+
+        try:
+            result = cdr.main([
+                '--config', str(config_file),
+                '--deploy-cron',
+                '--cron-scope', 'staged',
+                '--confirm-cron-activation',
+            ])
+        finally:
+            cdr.config.restore_state(snapshot)
+
+        captured = capsys.readouterr()
+
+        assert result is True
+        assert "first-staged" in activated['content']
+        assert "second-staged" in activated['content']
+        assert "manual-maintenance" in activated['content']
+        assert "Every staged .cron file will be activated" in captured.out
+
+    def test_deploy_cron_noninteractive_fails_closed_without_confirmation(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Non-interactive cron activation should stop before replacing crontab."""
+        home_dir = tmp_path / "home"
+        generated_dir = tmp_path / "output" / "crontab.d"
+        generated_dir.mkdir(parents=True)
+        (generated_dir / "local_dev.local.Landing_Zone.cron").write_text(
+            "* * * * * selected-runtime\n"
+        )
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("crontab_dir: {0}\n".format(generated_dir))
+        activated = {}
+
+        class DummyProcess:
+            def __init__(self, args, stdout=None, stderr=None, stdin=None):
+                self.args = args
+                self.returncode = 0
+
+            def communicate(self, input=None):
+                if self.args == ['crontab', '-']:
+                    activated['content'] = input.decode('utf-8')
+                return b'', b''
+
+        snapshot = cdr.config.snapshot_state()
+        monkeypatch.setenv('HOME', str(home_dir))
+        monkeypatch.setattr(ro, 'generate_cron_files', lambda runtime_ids=None: (True, "generated"))
+        monkeypatch.setattr(ro.subprocess, 'Popen', DummyProcess)
+        monkeypatch.setattr(ro, 'is_interactive_terminal', lambda: False, raising=False)
+        monkeypatch.setattr(
+            cdr,
+            'load_runtime_transfers',
+            lambda transfers_file=None, runtime_ids=None: pd.DataFrame([
+                {
+                    'runtime_id': 'local_dev.local',
+                    'system': 'local_dev',
+                    'users': 'local',
+                }
+            ]),
+        )
+        monkeypatch.setattr(
+            cdr,
+            'get_current_system',
+            lambda transfers_df=None, runtime_ids=None: 'local_dev',
+        )
+        monkeypatch.setattr(
+            cdr,
+            'get_current_user',
+            lambda transfers_df=None, runtime_ids=None: 'local',
+        )
+
+        try:
+            result = cdr.main([
+                '--config', str(config_file),
+                '--runtime-id', 'local_dev.local',
+                '--deploy-cron',
+            ])
+        finally:
+            cdr.config.restore_state(snapshot)
+
+        captured = capsys.readouterr()
+
+        assert result is False
+        assert 'content' not in activated
+        assert "scope 'selected'" in captured.out
+        assert "--confirm-cron-activation" in captured.out
+
 
 class TestRuntimeIdentityDetection:
     """Test system/user selection from filtered runtime transfer inventories."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -394,6 +394,30 @@ class TestOperatorCli:
             '--deploy-cron',
         ]
 
+    def test_deploy_cron_routes_scope_and_confirmation(self, monkeypatch):
+        """`landingzones deploy cron` should forward cron-scope activation options."""
+        captured = {}
+
+        def fake_main(argv=None):
+            captured['argv'] = argv
+            return True
+
+        monkeypatch.setattr(cli.cdr, 'main', fake_main)
+
+        rc = cli.main([
+            'deploy',
+            'cron',
+            '--cron-scope', 'expected',
+            '--confirm-cron-activation',
+        ])
+
+        assert rc == 0
+        assert captured['argv'] == [
+            '--cron-scope', 'expected',
+            '--confirm-cron-activation',
+            '--deploy-cron',
+        ]
+
     def test_report_transfers_routes_to_dashboard(self, monkeypatch):
         """`landingzones report transfers` should forward its dashboard arguments."""
         captured = {}


### PR DESCRIPTION
## Summary
- add selected/expected/staged cron activation scopes
- preserve unidentified cron fragments while excluding non-selected runtime fragments
- add expected-scope staged-file repair and explicit non-interactive confirmation

## Tests
- pixi run pytest tests/test_check_deployment_readiness.py::TestCronDeploymentPrompt tests/test_cli.py
- pixi run pytest

Closes #21.
Closes #22.
Closes #23.
Closes #24.