### PR TITLE
Finish transfer catalog follow-ups

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,6 +28,21 @@ _Avoid_: Runtime prefix, artifact prefix, user selection
 The build-written list of **Runtime IDs** represented by generated runtime artifacts.
 _Avoid_: Transfer inventory, runtime scan
 
+**Transfer Catalog**:
+The owner of transfer loading invariants for normalized transfer rows.
+_Avoid_: Per-command transfer parsing, report-only parser
+
+**Build/Runtime Catalog Loading**:
+The transfer catalog mode used by build and runtime validation commands. It
+requires runnable-script fields such as `log_file` and `flock_file`.
+_Avoid_: Generator parser, strict report loading
+
+**Reporting Catalog Loading**:
+The transfer catalog mode used by reporting analysis. It reads normalized
+transfer facts while allowing reporting-only inventories to omit runtime-only
+file columns.
+_Avoid_: Dashboard parser, loose runtime loading
+
 **Unidentified Cron Fragment**:
 A staged `.cron` file that does not carry a **Runtime ID** in its filename.
 _Avoid_: Unknown runtime, invalid cron
@@ -49,6 +64,9 @@ _Avoid_: Runtime identity, deploy boundary
 - A **Cron Fragment Set** can intentionally contain cron files for multiple **Runtime IDs** on the same **Execution Context**.
 - A **Runtime Selection** defaults to the selected **Runtime ID** exactly.
 - **Generated Runtime Metadata** describes the **Runtime IDs** represented by generated runtime artifacts.
+- The **Transfer Catalog** owns transfer loading invariants before command code consumes rows.
+- **Build/Runtime Catalog Loading** validates runnable transfer artifacts for `build`, deployment validation, and integration validation.
+- **Reporting Catalog Loading** preserves normalized transfer facts for dashboard analysis without requiring runtime-only file columns.
 - An **Unidentified Cron Fragment** can be preserved during activation without being treated as a **Landing Zone Runtime**.
 - An **Excluded Runtime Cron Fragment** may remain staged while being omitted from the active crontab.
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,33 @@ landingzones report transfers output/log/Landing_Zone_server1_prod.user1.transfe
 */15 * * * * /bin/sh output/scripts/local_copy.sh
 ```
 
+### Transfer Catalog Loading Modes
+
+The transfer catalog is the owner of transfer loading invariants. Future
+transfer-column, filtering, endpoint-expansion, validation, artifact-naming,
+boolean, tag, and warning behavior should land at the catalog seam before
+command code consumes the rows.
+
+`load_runtime_transfer_catalog` is the build/runtime loading mode. It keeps
+runtime validation enabled, including required runtime file columns such as
+`log_file` and `flock_file`, disabled-row filtering, exact `runtime_id`
+filtering, path-variable endpoint expansion, generated artifact names, boolean
+normalization, tag normalization, and shared lock/log warning metadata.
+
+`load_reporting_transfer_catalog` is the reporting/analysis loading mode. It
+uses the same normalized transfer facts, filtering, endpoint expansion,
+booleans, tags, and artifact naming, but reporting analysis can omit
+runtime-only `log_file` and `flock_file` columns because dashboards inspect
+transfer metadata and status logs instead of generating runnable scripts.
+
+Command boundaries:
+
+- `landingzones build` uses the runtime catalog.
+- `landingzones validate deployment` uses the runtime catalog.
+- `landingzones validate integration` uses the runtime catalog.
+- `landingzones validate separation` uses the reporting catalog.
+- `landingzones report transfers` uses the reporting catalog.
+
 ### Shared Main Transfer Locks
 
 `flock_file` is the top-level transfer lock for one generated script. Remote

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "landingzones"
-version = "1.1.8"
+version = "1.1.9"
 description = "Automated data transfer system using rsync and cron"
 channels = ["conda-forge"]
 platforms = ["osx-arm64", "osx-64", "linux-64"]

--- a/src/landingzones/__init__.py
+++ b/src/landingzones/__init__.py
@@ -7,7 +7,7 @@ This package provides tools for managing automated data transfers
 using a centralized configuration approach.
 """
 
-__version__ = '1.1.8'
+__version__ = '1.1.9'
 __author__ = 'SSI-DK'
 __description__ = 'Automated data transfer system using rsync and cron'
 

--- a/src/landingzones/check_deployment_readiness.py
+++ b/src/landingzones/check_deployment_readiness.py
@@ -18,7 +18,6 @@ import argparse
 
 from landingzones.config import config
 from landingzones.generate_cron_files import (
-    parse_transfers_file,
     normalize_source_path,
     sanitize_identifier,
     split_remote_path,
@@ -715,7 +714,10 @@ def load_test_with_data_transfers(
 
 def load_test_with_data_transfer_graph(transfers_file, base_dir, runtime_ids=None):
     """Load all test-with-data transfers with local endpoints absolutized."""
-    df = parse_transfers_file(transfers_file, runtime_ids=runtime_ids)
+    df = load_runtime_transfers(
+        transfers_file=transfers_file,
+        runtime_ids=runtime_ids,
+    )
     for column in ('source', 'destination'):
         df[column] = df[column].apply(
             lambda value: absolutize_local_endpoint(value, base_dir)

--- a/src/landingzones/plot_transfer_status.py
+++ b/src/landingzones/plot_transfer_status.py
@@ -18,6 +18,7 @@ from landingzones.config import config
 from landingzones import generate_cron_files as gcf
 from landingzones.transfer_loading import (
     definitions_for_system,
+    load_reporting_transfer_definitions,
     load_reporting_transfers,
     resolve_runtime_ids,
 )
@@ -859,12 +860,15 @@ def infer_report_system(config_file=None, transfers_file=None, runtime_ids=None)
     """Infer a system for default report-log resolution without prompting."""
     hostname = socket.gethostname().lower()
     try:
-        transfers_df = load_reporting_transfers(
+        definitions = load_reporting_transfer_definitions(
             config_file=config_file,
             transfers_file=transfers_file,
             runtime_ids=runtime_ids,
         )
-        systems = transfers_df["system"].unique()
+        systems = []
+        for definition in definitions:
+            if definition.system not in systems:
+                systems.append(definition.system)
         for system in systems:
             if str(system).lower() in hostname:
                 return system

--- a/src/landingzones/transfer_catalog.py
+++ b/src/landingzones/transfer_catalog.py
@@ -8,6 +8,7 @@ while command paths move behind this smaller interface.
 """
 
 from landingzones.config import config
+from landingzones.transfer_definitions import definitions_from_dataframe
 
 
 def load_transfer_catalog(
@@ -36,9 +37,40 @@ def load_transfer_catalog(
     )
 
 
+def load_transfer_definitions(
+    config_file=None,
+    transfers_file=None,
+    require_runtime_files=True,
+    runtime_ids=None,
+    system=None,
+    systems=None,
+):
+    """Load normalized transfer definitions after resolving config defaults."""
+    return definitions_from_dataframe(
+        load_transfer_catalog(
+            config_file=config_file,
+            transfers_file=transfers_file,
+            require_runtime_files=require_runtime_files,
+            runtime_ids=runtime_ids,
+            system=system,
+            systems=systems,
+        )
+    )
+
+
 def load_runtime_transfer_catalog(config_file=None, transfers_file=None, runtime_ids=None):
     """Load transfers with build/runtime validation enabled."""
     return load_transfer_catalog(
+        config_file=config_file,
+        transfers_file=transfers_file,
+        require_runtime_files=True,
+        runtime_ids=runtime_ids,
+    )
+
+
+def load_runtime_transfer_definitions(config_file=None, transfers_file=None, runtime_ids=None):
+    """Load transfer definitions with build/runtime validation enabled."""
+    return load_transfer_definitions(
         config_file=config_file,
         transfers_file=transfers_file,
         require_runtime_files=True,
@@ -54,6 +86,22 @@ def load_reporting_transfer_catalog(
 ):
     """Load transfers with reporting/analysis validation enabled."""
     return load_transfer_catalog(
+        config_file=config_file,
+        transfers_file=transfers_file,
+        require_runtime_files=False,
+        runtime_ids=runtime_ids,
+        system=system,
+    )
+
+
+def load_reporting_transfer_definitions(
+    config_file=None,
+    transfers_file=None,
+    runtime_ids=None,
+    system=None,
+):
+    """Load transfer definitions with reporting/analysis validation enabled."""
+    return load_transfer_definitions(
         config_file=config_file,
         transfers_file=transfers_file,
         require_runtime_files=False,

--- a/src/landingzones/transfer_loading.py
+++ b/src/landingzones/transfer_loading.py
@@ -100,9 +100,35 @@ def load_transfers(
     )
 
 
+def load_transfer_definitions(
+    config_file=None,
+    transfers_file=None,
+    require_runtime_files=True,
+    runtime_ids=None,
+    system=None,
+):
+    """Load normalized transfer definitions through the transfer catalog."""
+    return transfer_catalog.load_transfer_definitions(
+        config_file=config_file,
+        transfers_file=transfers_file,
+        require_runtime_files=require_runtime_files,
+        runtime_ids=runtime_ids,
+        system=system,
+    )
+
+
 def load_runtime_transfers(config_file=None, transfers_file=None, runtime_ids=None):
     """Load transfers with runtime/generator validation enabled."""
     return transfer_catalog.load_runtime_transfer_catalog(
+        config_file=config_file,
+        transfers_file=transfers_file,
+        runtime_ids=runtime_ids,
+    )
+
+
+def load_runtime_transfer_definitions(config_file=None, transfers_file=None, runtime_ids=None):
+    """Load transfer definitions with runtime/generator validation enabled."""
+    return transfer_catalog.load_runtime_transfer_definitions(
         config_file=config_file,
         transfers_file=transfers_file,
         runtime_ids=runtime_ids,
@@ -117,6 +143,21 @@ def load_reporting_transfers(
 ):
     """Load transfers with analysis/reporting validation enabled."""
     return transfer_catalog.load_reporting_transfer_catalog(
+        config_file=config_file,
+        transfers_file=transfers_file,
+        runtime_ids=runtime_ids,
+        system=system,
+    )
+
+
+def load_reporting_transfer_definitions(
+    config_file=None,
+    transfers_file=None,
+    runtime_ids=None,
+    system=None,
+):
+    """Load transfer definitions with analysis/reporting validation enabled."""
+    return transfer_catalog.load_reporting_transfer_definitions(
         config_file=config_file,
         transfers_file=transfers_file,
         runtime_ids=runtime_ids,

--- a/tests/test_check_deployment_readiness.py
+++ b/tests/test_check_deployment_readiness.py
@@ -11,6 +11,8 @@ import pandas as pd
 
 from landingzones import check_deployment_readiness as cdr
 from landingzones import readiness_ops as ro
+from landingzones import transfer_catalog
+from landingzones.table import TransferTable
 
 
 class TestParseRemoteDestination:
@@ -833,6 +835,67 @@ class TestRuntimeIdentityDetection:
 
         assert result is True
         assert captured['runtime_ids'] == ['local_dev.local']
+
+    def test_validate_deployment_loads_transfers_through_runtime_catalog(
+        self, tmp_path, monkeypatch
+    ):
+        """Deployment validation should use the catalog runtime-validation path."""
+        src = tmp_path / "src"
+        dst = tmp_path / "dst"
+        src.mkdir()
+        dst.mkdir()
+        transfers_file = tmp_path / "transfers.tsv"
+        transfers_file.write_text("placeholder\n")
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            "transfers_file: {0}\n"
+            "runtime_ids:\n"
+            "  - local_dev.local\n".format(transfers_file)
+        )
+        catalog_row = {
+            'runtime_id': 'local_dev.local',
+            'system': 'local_dev',
+            'users': 'local',
+            'source': str(src),
+            'source_port': '',
+            'destination': str(dst),
+            'destination_port': '',
+            'log_file': '',
+            'flock_file': '',
+        }
+        loaded = TransferTable([catalog_row], columns=list(catalog_row))
+        calls = []
+
+        def fake_load_runtime_transfer_catalog(
+            config_file=None, transfers_file=None, runtime_ids=None
+        ):
+            calls.append({
+                'config_file': config_file,
+                'transfers_file': transfers_file,
+                'runtime_ids': runtime_ids,
+            })
+            return loaded
+
+        config_snapshot = cdr.config.snapshot_state()
+        monkeypatch.setattr(cdr, 'check_required_tools', lambda: True)
+        monkeypatch.setattr(cdr, 'check_flock_command', lambda system: True)
+        monkeypatch.setattr(
+            transfer_catalog,
+            'load_runtime_transfer_catalog',
+            fake_load_runtime_transfer_catalog,
+        )
+
+        try:
+            result = cdr.main(['--config', str(config_file)])
+        finally:
+            cdr.config.restore_state(config_snapshot)
+
+        assert result is True
+        assert calls == [{
+            'config_file': None,
+            'transfers_file': str(transfers_file),
+            'runtime_ids': ['local_dev.local'],
+        }]
 
     def test_validate_deployment_prints_shared_main_lock_warnings(
         self, tmp_path, monkeypatch, capsys
@@ -1746,6 +1809,77 @@ class TestTestWithData:
 
         assert subset_df['source'].tolist() == ['$LZ_TEST_ROOT/source/']
         assert subset_df['destination'].tolist() == ['$LZ_TEST_ROOT/dest/']
+
+    def test_load_test_with_data_transfer_graph_uses_runtime_catalog(
+        self, tmp_path, monkeypatch
+    ):
+        """test-with-data transfer selection should load through the runtime catalog."""
+        transfers_file = tmp_path / 'transfers.tsv'
+        transfers_file.write_text(
+            "\n".join([
+                "identifiers\truntime_id\tsystem\tusers\tsource\tdestination\tlog_file\tflock_file",
+                "direct_parse\tignored.runtime\ttestbox\trunner\tdirect_src/\tdirect_dst/\tdirect.log\tdirect.lock",
+                "",
+            ])
+        )
+        catalog_row = {
+            'identifiers': 'catalog_transfer',
+            'runtime_id': 'selected.runtime',
+            'system_user': 'selected.runtime',
+            'system': 'testbox',
+            'users': 'runner',
+            'source': 'catalog_src/',
+            'source_port': '',
+            'destination': 'catalog_dst/',
+            'destination_port': '',
+            'rsync_options': '',
+            'io_nice': '',
+            'frequency': '',
+            'log_file': str(tmp_path / 'catalog.log'),
+            'flock_file': str(tmp_path / 'catalog.lock'),
+            'flow_group': '',
+            'tags': '',
+            'is_entry_point': 'FALSE',
+            'is_end_point': 'FALSE',
+            'notify_on_success': 'FALSE',
+            'notify_on_error': 'FALSE',
+            'script_name': 'catalog_transfer.sh',
+        }
+        loaded = TransferTable([catalog_row], columns=list(catalog_row))
+        calls = []
+
+        def fake_load_runtime_transfer_catalog(
+            config_file=None, transfers_file=None, runtime_ids=None
+        ):
+            calls.append({
+                'config_file': config_file,
+                'transfers_file': transfers_file,
+                'runtime_ids': runtime_ids,
+            })
+            return loaded
+
+        monkeypatch.setattr(
+            transfer_catalog,
+            'load_runtime_transfer_catalog',
+            fake_load_runtime_transfer_catalog,
+        )
+
+        transfers_df = cdr.load_test_with_data_transfer_graph(
+            str(transfers_file),
+            str(tmp_path),
+            runtime_ids=['selected.runtime'],
+        )
+
+        assert calls == [{
+            'config_file': None,
+            'transfers_file': str(transfers_file),
+            'runtime_ids': ['selected.runtime'],
+        }]
+        assert transfers_df['identifiers'].tolist() == ['catalog_transfer']
+        assert transfers_df['source'].tolist() == [str(tmp_path / 'catalog_src') + '/']
+        assert transfers_df['destination'].tolist() == [
+            str(tmp_path / 'catalog_dst') + '/'
+        ]
 
     def test_build_test_with_data_handoffs_identifies_next_system_user(self, tmp_path):
         """A destination that feeds another system should produce a handoff hint."""

--- a/tests/test_operator_docs.py
+++ b/tests/test_operator_docs.py
@@ -21,3 +21,33 @@ def test_readme_documents_shared_lock_startup_jitter():
     assert "transfer-status and notification-status locks" in normalized_readme_text
     assert "LZ_DEBUG_CLI=1" in readme_text
     assert "does not change the cron cadence" in normalized_readme_text
+
+
+def test_readme_documents_transfer_catalog_loading_modes():
+    """README should keep transfer-loading command boundaries explicit."""
+    readme_path = os.path.join(APP_ROOT, "README.md")
+    readme_text = open(readme_path, "r").read()
+    normalized_readme_text = " ".join(readme_text.split())
+
+    assert "Transfer Catalog Loading Modes" in readme_text
+    assert "owner of transfer loading invariants" in normalized_readme_text
+    assert "`load_runtime_transfer_catalog`" in readme_text
+    assert "`load_reporting_transfer_catalog`" in readme_text
+    assert "`landingzones build` uses the runtime catalog" in normalized_readme_text
+    assert "`landingzones validate deployment` uses the runtime catalog" in normalized_readme_text
+    assert "`landingzones validate integration` uses the runtime catalog" in normalized_readme_text
+    assert "`landingzones validate separation` uses the reporting catalog" in normalized_readme_text
+    assert "`landingzones report transfers` uses the reporting catalog" in normalized_readme_text
+    assert "reporting analysis can omit runtime-only `log_file` and `flock_file` columns" in normalized_readme_text
+
+
+def test_context_names_transfer_catalog_as_invariant_owner():
+    """Domain language should point future transfer-loading changes at catalog first."""
+    context_path = os.path.join(APP_ROOT, "CONTEXT.md")
+    context_text = open(context_path, "r").read()
+    normalized_context_text = " ".join(context_text.split())
+
+    assert "**Transfer Catalog**" in context_text
+    assert "owner of transfer loading invariants" in normalized_context_text
+    assert "Build/Runtime Catalog Loading" in context_text
+    assert "Reporting Catalog Loading" in context_text

--- a/tests/test_plot_transfer_status.py
+++ b/tests/test_plot_transfer_status.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 from landingzones import plot_transfer_status as pts
 from landingzones import transfer_catalog
+from landingzones.transfer_definitions import TransferDefinition
 
 
 def make_transfers_tsv(tmp_path):
@@ -320,6 +321,59 @@ def test_load_transfers_for_reporting_uses_reporting_catalog(monkeypatch):
             "transfers_file": "/tmp/transfers.tsv",
             "runtime_ids": ["local_dev.local"],
             "system": "test_local",
+        }
+    ]
+
+
+def test_infer_report_system_uses_reporting_definitions(monkeypatch):
+    """System inference reads transfer facts through normalized definitions."""
+    calls = []
+
+    def fake_load_reporting_transfer_definitions(
+        config_file=None,
+        transfers_file=None,
+        runtime_ids=None,
+        system=None,
+    ):
+        calls.append(
+            {
+                "config_file": config_file,
+                "transfers_file": transfers_file,
+                "runtime_ids": runtime_ids,
+                "system": system,
+            }
+        )
+        return [
+            TransferDefinition(
+                identifier="stage_lab",
+                system="test-local-host",
+                user="local",
+                source="/source/inbox/*",
+                destination="/flow/stage/",
+                runtime_id="local_dev.local",
+            )
+        ]
+
+    monkeypatch.setattr(
+        pts,
+        "load_reporting_transfer_definitions",
+        fake_load_reporting_transfer_definitions,
+    )
+    monkeypatch.setattr(pts.socket, "gethostname", lambda: "test-local-host-01")
+
+    result = pts.infer_report_system(
+        config_file="/tmp/config.yaml",
+        transfers_file="/tmp/transfers.tsv",
+        runtime_ids=["local_dev.local"],
+    )
+
+    assert result == "test-local-host"
+    assert calls == [
+        {
+            "config_file": "/tmp/config.yaml",
+            "transfers_file": "/tmp/transfers.tsv",
+            "runtime_ids": ["local_dev.local"],
+            "system": None,
         }
     ]
 

--- a/tests/test_transfer_catalog.py
+++ b/tests/test_transfer_catalog.py
@@ -2,10 +2,13 @@
 # -*- coding: utf-8 -*-
 """Tests for transfer catalog loading."""
 
+import pytest
+
 from landingzones import generate_cron_files as gcf
 from landingzones import transfer_catalog
 from landingzones.table import TransferTable
 from landingzones.transfer_catalog import (
+    load_reporting_transfer_definitions,
     load_reporting_transfer_catalog,
     load_runtime_transfer_catalog,
 )
@@ -18,11 +21,12 @@ def test_runtime_catalog_preserves_build_loading_invariants(tmp_path):
     transfers_file.write_text(
         "\n".join(
             [
-                "runtime_id\tenabled\tsystem\tusers\tsource\tdestination\tlog_file\tflock_file\tflow_group\tis_entry_point\tnotify_on_success",
-                "local_dev.local\tTRUE\tlocal_dev\tlocal\t${SRC_ROOT}/in/\t${DST_ROOT}/out/\ttransfer.log\ttransfer.lock\tflow one\tyes\t1",
-                "local_dev.local\tTRUE\tlocal_dev\tlocal\t${SRC_ROOT}/second/\t${DST_ROOT}/second/\ttransfer.log\ttransfer.lock\tflow one\tfalse\tfalse",
-                "disabled.local\tFALSE\tlocal_dev\tlocal\t${SRC_ROOT}/disabled/\t${DST_ROOT}/disabled/\tdisabled.log\tdisabled.lock\t\t\t",
-                "#commented.local\tTRUE\tlocal_dev\tlocal\t${SRC_ROOT}/commented/\t${DST_ROOT}/commented/\tcommented.log\tcommented.lock\t\t\t",
+                "runtime_id\tenabled\tsystem\tusers\tsource\tdestination\tlog_file\tflock_file\tflow_group\ttags\tis_entry_point\tnotify_on_success",
+                "local_dev.local\tTRUE\tlocal_dev\tlocal\t${SRC_ROOT}/in/\t${DST_ROOT}/out/\ttransfer.log\ttransfer.lock\tflow one\tLab, heartbeat\tyes\t1",
+                "local_dev.local\tTRUE\tlocal_dev\tlocal\t${SRC_ROOT}/second/\t${DST_ROOT}/second/\ttransfer.log\ttransfer.lock\tflow one\tLAB\tfalse\tfalse",
+                "other.local\tTRUE\tlocal_dev\tlocal\t${SRC_ROOT}/other/\t${DST_ROOT}/other/\tother.log\tother.lock\tflow one\tother\tfalse\tfalse",
+                "disabled.local\tFALSE\tlocal_dev\tlocal\t${SRC_ROOT}/disabled/\t${DST_ROOT}/disabled/\tdisabled.log\tdisabled.lock\t\t\t\t",
+                "#commented.local\tTRUE\tlocal_dev\tlocal\t${SRC_ROOT}/commented/\t${DST_ROOT}/commented/\tcommented.log\tcommented.lock\t\t\t\t",
             ]
         )
     )
@@ -59,8 +63,11 @@ def test_runtime_catalog_preserves_build_loading_invariants(tmp_path):
     assert catalog.iloc[0]["script_name"] == "prod_server__transfer_001.sh"
     assert catalog.iloc[0]["is_entry_point"] == "TRUE"
     assert catalog.iloc[0]["notify_on_success"] == "TRUE"
+    assert catalog.iloc[0]["tags"] == "heartbeat,lab"
     assert catalog.iloc[1]["is_entry_point"] == "FALSE"
+    assert catalog.iloc[1]["tags"] == "lab"
     assert catalog.attrs["shared_file_pair_warnings"]
+    assert catalog.attrs["shared_main_lock_warnings"]
 
 
 def test_build_command_loads_transfers_through_catalog(tmp_path, monkeypatch):
@@ -176,3 +183,91 @@ def test_reporting_catalog_relaxes_runtime_file_validation(tmp_path):
 
     assert list(catalog["identifiers"]) == ["report_transfer"]
     assert list(catalog["runtime_id"]) == ["local_dev.local"]
+
+
+def test_runtime_catalog_keeps_runtime_file_validation_distinct_from_reporting(tmp_path):
+    """Runtime-validation mode should reject TSVs accepted by reporting mode."""
+    transfers_file = tmp_path / "transfers.tsv"
+    config_file = tmp_path / "config.yaml"
+    transfers_file.write_text(
+        "\n".join(
+            [
+                "identifiers\truntime_id\tenabled\tsystem\tusers\tsource\tdestination\ttags",
+                "report_transfer\tlocal_dev.local\tTRUE\tlocal_dev\tlocal\t/source/\t/destination/\treporting",
+            ]
+        )
+    )
+    config_file.write_text(
+        "transfers_file: {0}\n"
+        "runtime_ids:\n"
+        "  - local_dev.local\n".format(transfers_file)
+    )
+
+    snapshot = gcf.config.snapshot_state()
+    try:
+        reporting_catalog = load_reporting_transfer_catalog(config_file=str(config_file))
+        with pytest.raises(ValueError, match="log_file"):
+            load_runtime_transfer_catalog(config_file=str(config_file))
+    finally:
+        gcf.config.restore_state(snapshot)
+
+    assert list(reporting_catalog["identifiers"]) == ["report_transfer"]
+
+
+def test_reporting_catalog_exposes_normalized_definitions_and_keeps_dataframe_compatibility(tmp_path):
+    """Catalog callers can use typed transfer facts without losing dataframe rows."""
+    transfers_file = tmp_path / "transfers.tsv"
+    config_file = tmp_path / "config.yaml"
+    transfers_file.write_text(
+        "\n".join(
+            [
+                "identifiers\truntime_id\tenabled\tsystem\tusers\tsource\tdestination\tsource_port\tdestination_port\ttags\tis_entry_point\tis_end_point\tnotify_on_success\tnotify_on_error",
+                "stage_lab\tlocal_dev.local\tTRUE\tlocal_dev\tlocal\t${SRC_ROOT}/in/*\tremote:${DST_ROOT}/out/\t2222\t2200.0\tLab, heartbeat\tYES\t0\t1\tfalse",
+            ]
+        )
+    )
+    config_file.write_text(
+        "transfers_file: {0}\n"
+        "runtime_ids:\n"
+        "  - local_dev.local\n"
+        "path_variables:\n"
+        "  SRC_ROOT: {1}\n"
+        "  DST_ROOT: {2}\n".format(
+            transfers_file,
+            tmp_path / "source",
+            tmp_path / "destination",
+        )
+    )
+
+    snapshot = gcf.config.snapshot_state()
+    try:
+        definitions = load_reporting_transfer_definitions(config_file=str(config_file))
+        catalog = load_reporting_transfer_catalog(config_file=str(config_file))
+    finally:
+        gcf.config.restore_state(snapshot)
+
+    assert len(definitions) == 1
+    definition = definitions[0]
+    assert definition.identifier == "stage_lab"
+    assert definition.runtime_id == "local_dev.local"
+    assert definition.system_user == "local_dev.local"
+    assert definition.system == "local_dev"
+    assert definition.user == "local"
+    assert definition.source == str(tmp_path / "source" / "in") + "/*"
+    assert definition.destination == "remote:{0}/out/".format(tmp_path / "destination")
+    assert definition.source_port == "2222"
+    assert definition.destination_port == "2200"
+    assert definition.tags == ("heartbeat", "lab")
+    assert definition.is_entry_point is True
+    assert definition.is_end_point is False
+    assert definition.notify_on_success is True
+    assert definition.notify_on_error is False
+    assert definition.script_name == "stage_lab.sh"
+
+    assert list(catalog["identifiers"]) == ["stage_lab"]
+    assert catalog.iloc[0]["is_entry_point"] == "TRUE"
+    assert catalog.iloc[0]["is_end_point"] == "FALSE"
+    assert catalog.iloc[0]["notify_on_success"] == "TRUE"
+    assert catalog.iloc[0]["notify_on_error"] == "FALSE"
+    assert catalog.iloc[0]["tags"] == "heartbeat,lab"
+    assert catalog.iloc[0]["destination_port"] == "2200"


### PR DESCRIPTION
## Summary
- route deployment readiness and test-with-data transfer loading through the runtime transfer catalog
- expose normalized transfer definition loaders while preserving dataframe catalog callers
- migrate report-system inference to normalized definitions
- document transfer catalog loading modes and lock catalog invariants with regression tests
- bump the app hotfix version to 1.1.9

## Tests
- pixi run pytest tests/test_transfer_catalog.py tests/test_operator_docs.py tests/test_plot_transfer_status.py tests/test_check_deployment_readiness.py
- pixi run pytest
- pixi run pytest tests/test_cli.py::TestOperatorCli::test_version_prints_package_version tests/test_python_standalone_packaging.py::test_github_action_creates_release_from_app_version

Closes #17.
Closes #18.
Closes #19.